### PR TITLE
chore(ci): fetch supported boards from build config

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,7 +55,7 @@ jobs:
           echo "yq-version=$(curl -s https://api.github.com/repos/mikefarah/yq/releases/latest | grep tag_name | grep -oE 'v[0-9a-z\.-]+')" >>"$GITHUB_OUTPUT"
 
       - name: Install yq
-        uses: chrisdickinson/setup-yq@v1.0.1
+        uses: chrisdickinson/setup-yq@latest
         with:
           yq-version: ${{ steps.yq.outputs.yq-version }}
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,7 +47,17 @@ jobs:
             image-
 
       - name: Install build dependencies
-        run: sudo apt-get install -y --no-install-recommends build-essential
+        run: sudo apt-get install -y --no-install-recommends build-essential curl
+
+      - name: Fetch latest version of yq
+        id: yq
+        run: |
+          echo "yq-version=$(curl -s https://api.github.com/repos/mikefarah/yq/releases/latest | grep tag_name | grep -oE 'v[0-9a-z\.-]+')" >>"$GITHUB_OUTPUT"
+
+      - name: Install yq
+        uses: chrisdickinson/setup-yq@v1.0.1
+        with:
+          yq-version: ${{ steps.yq.outputs.yq-version }}
 
       - name: Fetch version from git history
         uses: codfish/semantic-release-action@v3

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+CODEOWNERS

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,3 @@
+# This ensures that I am the required
+# reviewer for all pull requests.
+* nicklasfrahm

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,3 @@
 # This ensures that I am the required
 # reviewer for all pull requests.
-* nicklasfrahm
+* nicklas.frahm@gmail.com

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -20,7 +20,11 @@ parse_args() {
     exit 1
   fi
   board="$1"
+
   version="$2"
+  if [[ "$version" == "v" ]]; then
+    version="v$(git describe --always --tags --dirty)"
+  fi
 
   # Fetch supported boards from CI configuration.
   mapfile -t supported_boards < <(yq '.jobs.image.strategy.matrix.board' .github/workflows/build.yml | cut -d ' ' -f 2)

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -11,7 +11,6 @@ OUTPUT_DIR="output"
 USERNAME="nicklasfrahm"
 
 # Global variables.
-supported_boards=("nanopi-r5s" "uefi-x86" "rpi4b")
 board=""
 version=""
 
@@ -22,6 +21,9 @@ parse_args() {
   fi
   board="$1"
   version="$2"
+
+  # Fetch supported boards from CI configuration.
+  mapfile -t supported_boards < <(yq '.jobs.image.strategy.matrix.board' .github/workflows/build.yml | cut -d ' ' -f 2)
 
   is_supported_board=false
   for supported_board in "${supported_boards[@]}"; do


### PR DESCRIPTION
This fetches the information about the supported boards automatically from the CI configuration.