### PR TITLE
fix(rpi4b): patch cmdline for cloud-init

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,10 @@ permissions:
   issues: write
   pull-requests: write
 
+concurrency:
+  group: build-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   image:
     name: Image

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ An [Armbian][armbian]-based firmware image that uses cloud-init for configuratio
 
 - [`nanopi-r5s`][nanopi-r5s]
 - `uefi-x86`
+- `rpi4b`
 
 ## 🚀 Quickstart
 
@@ -29,8 +30,13 @@ The `armbian-install` script does not create the right partition layout when usi
 1. SSH into the device and run the following command:
 
    ```bash
+   # Install pv to get a progress bar.
    sudo apt install -y pv
-   sudo dd if=/uefi-x86.img of=/dev/mmcblk0 bs=1M
+   # DANGER! This will overwrite the first disk on the host.
+   export TARGET_DISK=/dev/sdX
+   sudo dd if=/uefi-x86.img bs=4M |
+     pv -tpreb -s $(sudo stat -c "%s" /uefi-x86.img) |
+     sudo dd of="$TARGET_DISK" bs=4M
    ```
 
 1. Reboot the device.

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ Make sure to have a recent version of [Docker][docker], [Git][git] and `build-es
 make build
 ```
 
+After flashing the image to an SD card, you should be able to connect to it via SSH using the username `nicklasfrahm` and the `id_ed25519` private key with the comment `nicklasfrahm@gl552vw`. Alternatively, you may log in locally using the username `root` and the password `cloudy1234`.
+
 ## 💡 Known issues
 
 ### 🪄 Can't use `armbian-install` on `uefi-x86`

--- a/config/userpatches/customize-image.sh
+++ b/config/userpatches/customize-image.sh
@@ -140,14 +140,22 @@ configure_cloud_init() {
   grub_config="/etc/default/grub"
   extra_kernel_args="ds=nocloud;s=file://boot/cloud-init/"
   if [[ -f "$grub_config" ]]; then
-    echo "Using GRUB ..."
+    echo "Patching GRUB ..."
     sed -i "s|^GRUB_CMDLINE_LINUX=.*|GRUB_CMDLINE_LINUX=\"'$extra_kernel_args'\"|" "$grub_config"
     update-grub
-  else
-    echo "Using u-boot ..."
+  fi
+
+  if [[ -f "/boot/armbianEnv.txt" ]]; then
+    echo "Patching u-boot ..."
     echo "extraargs=$extra_kernel_args" >>/boot/armbianEnv.txt
   fi
-  # TODO: Modify cmdline.txt on the RPICFG partition.
+
+  cmdline_file=$(find / -name cmdline.txt 2>/dev/null | head -n 1)
+  if [[ -n "$cmdline_file" ]] && [[ -f "$cmdline_file" ]]; then
+    echo "Patching RPI u-boot ..."
+    rpi_extra_kernel_args="$extra_kernel_args cgroup_memory=1 cgroup_enable=memory cgroup_enable=cpuset"
+    sed -i "s|^\(.*\)|\1 $rpi_extra_kernel_args|" "$cmdline_file"
+  fi
 
   # TODO: Investigate how we can inject cloud-init configuration
   # after image build to reduce build time and improve flexibility.

--- a/config/userpatches/customize-image.sh
+++ b/config/userpatches/customize-image.sh
@@ -40,8 +40,8 @@ configure_users() {
   rm /root/.not_logged_in_yet
 
   # Set random root password.
-  ROOT_PASSWORD=$(openssl rand -hex 32)
-  echo "root:${ROOT_PASSWORD}" | chpasswd
+  root_password="cloudy1234"
+  echo "root:$root_password" | chpasswd
 
   # Disable autologin.
   rm -f /etc/systemd/system/getty@.service.d/override.conf

--- a/config/userpatches/customize-image.sh
+++ b/config/userpatches/customize-image.sh
@@ -147,6 +147,7 @@ configure_cloud_init() {
     echo "Using u-boot ..."
     echo "extraargs=$extra_kernel_args" >>/boot/armbianEnv.txt
   fi
+  # TODO: Modify cmdline.txt on the RPICFG partition.
 
   # TODO: Investigate how we can inject cloud-init configuration
   # after image build to reduce build time and improve flexibility.


### PR DESCRIPTION
Currently, the `rpi4b` is not picking up the changes to the commandline from the `armbianEnv.txt`. The reason for this could be that there is an additional partition called `RPICFG`, which contains a `cmdline.txt` file.

Also resolves the following issues:
- #7